### PR TITLE
Always get publify_core from the repository in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,4 @@ source "https://rubygems.org"
 # Dependencies are specified in publify_amazon_sidebar.gemspec.
 gemspec
 
-if File.exist? File.join("..", "publify_core")
-  gem "publify_core", path: "../publify_core"
-else
-  gem "publify_core", git: "https://github.com/publify/publify_core.git"
-end
+gem "publify_core", git: "https://github.com/publify/publify_core.git"


### PR DESCRIPTION
This makes dependabot work and should be fine for normal development.
