### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'spec/dummy/bin/*'
     - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 Rails:
   Enabled: true

--- a/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Amazon sidebar for the Publify blogging system."
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.0.0"
 
   s.files = File.open("Manifest.txt").readlines.map(&:chomp)
 


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
