### PR TITLE
Drop support for Ruby versions that are end-of-life

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
     - 'spec/dummy/bin/*'
     - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Rails:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
     - 'spec/dummy/bin/*'
     - 'spec/dummy/db/schema.rb'
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 Rails:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Support Ruby 3.2, 3.3 and 3.4
+
 ## 10.0.0 / 2023-06-25
 
 * Support Ruby 2.7, 3.0, 3.1 and 3.2

--- a/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar.gemspec
@@ -1,34 +1,35 @@
 # frozen_string_literal: true
 
-# Maintain your gem's version:
 require_relative "lib/publify_amazon_sidebar/version"
 
-# Describe your gem and declare its dependencies:
-Gem::Specification.new do |s|
-  s.name        = "publify_amazon_sidebar"
-  s.version     = PublifyAmazonSidebar::VERSION
-  s.authors     = ["Matijs van Zuijlen"]
-  s.email       = ["matijs@matijs.net"]
-  s.homepage    = "https://publify.github.io/"
-  s.summary     = "Amazon sidebar for the Publify blogging system."
-  s.description = "Amazon sidebar for the Publify blogging system."
-  s.license     = "MIT"
+Gem::Specification.new do |spec|
+  spec.name = "publify_amazon_sidebar"
+  spec.version = PublifyAmazonSidebar::VERSION
+  spec.authors = ["Matijs van Zuijlen"]
+  spec.email = ["matijs@matijs.net"]
 
-  s.required_ruby_version = ">= 3.0.0"
+  spec.summary = "Amazon sidebar for the Publify blogging system."
+  spec.description = "Amazon sidebar for the Publify blogging system."
+  spec.homepage = "https://publify.github.io/"
+  spec.license = "MIT"
 
-  s.files = File.open("Manifest.txt").readlines.map(&:chomp)
+  spec.required_ruby_version = ">= 3.1.0"
 
-  s.add_dependency "publify_core", "~> 10.0.0"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  s.add_development_dependency "rspec-rails", "~> 6.0"
-  s.add_development_dependency "rubocop", "~> 1.64.1"
-  s.add_development_dependency "rubocop-capybara", "~> 2.21.0"
-  s.add_development_dependency "rubocop-factory_bot", "~> 2.26.1"
-  s.add_development_dependency "rubocop-performance", "~> 1.21.1"
-  s.add_development_dependency "rubocop-rails", "~> 2.25.0"
-  s.add_development_dependency "rubocop-rspec", "~> 3.0.1"
-  s.add_development_dependency "rubocop-rspec_rails", "~> 2.30.0"
-  s.add_development_dependency "simplecov", "~> 0.22.0"
-  s.add_development_dependency "sqlite3", "~> 1.6"
-  s.metadata["rubygems_mfa_required"] = "true"
+  spec.files = File.open("Manifest.txt").readlines.map(&:chomp)
+
+  spec.add_dependency "publify_core", "~> 10.0.0"
+
+  spec.add_development_dependency "rspec-rails", "~> 6.0"
+  spec.add_development_dependency "rubocop", "~> 1.64.1"
+  spec.add_development_dependency "rubocop-capybara", "~> 2.21.0"
+  spec.add_development_dependency "rubocop-factory_bot", "~> 2.26.1"
+  spec.add_development_dependency "rubocop-performance", "~> 1.21.1"
+  spec.add_development_dependency "rubocop-rails", "~> 2.25.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 3.0.1"
+  spec.add_development_dependency "rubocop-rspec_rails", "~> 2.30.0"
+  spec.add_development_dependency "simplecov", "~> 0.22.0"
+  spec.add_development_dependency "sqlite3", "~> 1.6"
 end

--- a/publify_amazon_sidebar.gemspec
+++ b/publify_amazon_sidebar.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://publify.github.io/"
   spec.license = "MIT"
 
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
- **Drop support for Ruby 3.0**
- **Drop support for Ruby 3.1**
