### PR TITLE
Remove permissions from GITHUB_TOKEN in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,6 +4,8 @@
 
 name: CI
 
+permissions: {}
+
 "on":
   push:
     branches:


### PR DESCRIPTION
The token is not used so does not need any permissions.
